### PR TITLE
Update article_list.html

### DIFF
--- a/djangonautic/articles/templates/articles/article_list.html
+++ b/djangonautic/articles/templates/articles/article_list.html
@@ -1,4 +1,4 @@
-{% load static from staticfiles %}
+{% load static %}
 
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
The error message indicates that the 'staticfiles' tag library is not registered in your Django project. The error occurs in the template file articleList.html at line 1.

To resolve this issue, you can follow these steps:

    Open the articleList.html template file located at djangonautic/articles/templates/articles/articleList.html.
    In the first line of the template file, you have the following code: {% load static from staticfiles %}.
    Replace {% load static from staticfiles %} with {% load static %}.
    Save the file and restart your Django development server.
    Refresh the webpage and check if the error is resolved.

The {% load static from staticfiles %} template tag was used in earlier versions of Django to load static files. However, in more recent versions, you only need to use {% load static %} to load static files.

By making this change, the template engine will correctly load the static files and resolve the 'staticfiles' is not a registered tag library error.